### PR TITLE
Update org.bukkit.entity.Egg Translations

### DIFF
--- a/BukkitApi/org/bukkit/entity/Egg.java
+++ b/BukkitApi/org/bukkit/entity/Egg.java
@@ -1,6 +1,8 @@
 package org.bukkit.entity;
 
 /**
- * 我创造了生命? 不,那是上帝, 上帝才是掷骰子的 (代表抛出的鸡蛋).
+ * 代表抛出的鸡蛋. 
+ * <p>
+ * 原文：Represents a thrown egg. 
  */
 public interface Egg extends ThrowableProjectile {}


### PR DESCRIPTION
In no place have I ever seen such words as ‘上帝’ in the English document (Spigot 1.12.2 and Spigot 1.16.3).
I view it as some additional documentations created sometime between 1.12.2 and 1.16, but later removed for some reason , while your translations for these deprecated documentations remained. 

原文里面被移除的内容而文档没有及时更新？
或者是翻译时多出来的？