### PR TITLE
Fix typo (Boos->Boss)

### DIFF
--- a/BukkitApi/org/bukkit/Bukkit.java
+++ b/BukkitApi/org/bukkit/Bukkit.java
@@ -2050,7 +2050,7 @@ public final class Bukkit {
     }
 
     /**
-     * 创建一个Boos血量条实例. 血量条的进度默认为1.0.
+     * 创建一个Boss血量条实例. 血量条的进度默认为1.0.
      * <p>
      * 原文:
      * Creates a boss bar instance to display to players. The progress
@@ -2068,7 +2068,7 @@ public final class Bukkit {
     }
 
     /**
-     * 创建一个Boos血量条实例. 血量条的进度默认为1.0.
+     * 创建一个Boss血量条实例. 血量条的进度默认为1.0.
      * <br>
      * 该方法创建的实例会被添加到服务器的持久化存储空间中, 命令将可以编辑它们, 服务器重启后会被恢复.
      * <p>

--- a/BukkitApi/org/bukkit/Server.java
+++ b/BukkitApi/org/bukkit/Server.java
@@ -1787,7 +1787,7 @@ public interface Server extends PluginMessageRecipient {
     public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
 
     /**
-     * 创建一个Boos血量条实例. 血量条的进度默认为1.0.
+     * 创建一个Boss血量条实例. 血量条的进度默认为1.0.
      * <p>
      * 原文:
      * Creates a boss bar instance to display to players. The progress
@@ -1803,7 +1803,7 @@ public interface Server extends PluginMessageRecipient {
     BossBar createBossBar(@Nullable String title, @NotNull BarColor color, @NotNull BarStyle style, @NotNull BarFlag... flags);
 
     /**
-     * 创建一个Boos血量条实例. 血量条的进度默认为1.0.
+     * 创建一个Boss血量条实例. 血量条的进度默认为1.0.
      * <br>
      * 该方法创建的实例会被添加到服务器的持久化存储空间中, 命令将可以编辑它们, 服务器重启后会被恢复.
      * <p>

--- a/BukkitApi/org/bukkit/boss/BossBar.java
+++ b/BukkitApi/org/bukkit/boss/BossBar.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 public interface BossBar {
 
     /**
-     * 用于获取该Boos血量条的标题.
+     * 用于获取该Boss血量条的标题.
      * <p>
      * 原文:Returns the title of this boss bar
      *


### PR DESCRIPTION
Boss 一词不必译，但有五处错写作 Boos，今改。望管理员斧正。