### PR TITLE
更新一部分至Minecraft Wiki的链接

### DIFF
--- a/BukkitApi/org/bukkit/GameRule.java
+++ b/BukkitApi/org/bukkit/GameRule.java
@@ -126,12 +126,12 @@ public final class GameRule<T> {
     public static final GameRule<Boolean> SPECTATORS_GENERATE_CHUNKS = new GameRule<>("spectatorsGenerateChunks", Boolean.class);
 
     /**
-     * 是否禁用<a href="https://minecraft-zh.gamepedia.com/%E8%A2%AD%E5%87%BB" target="_blank">袭击</a>.
+     * 是否禁用<a href="https://zh.minecraft.wiki/w/%E8%A2%AD%E5%87%BB" target="_blank">袭击</a>.
      */
     public static final GameRule<Boolean> DISABLE_RAIDS = new GameRule<>("disableRaids", Boolean.class);
 
     /**
-     * <a href="https://minecraft-zh.gamepedia.com/%E5%B9%BB%E7%BF%BC" target="_blank">幻翼</a>是否在夜晚生成.
+     * <a href="https://zh.minecraft.wiki/w/%E5%B9%BB%E7%BF%BC" target="_blank">幻翼</a>是否在夜晚生成.
      */
     public static final GameRule<Boolean> DO_INSOMNIA = new GameRule<>("doInsomnia", Boolean.class);
 
@@ -161,12 +161,12 @@ public final class GameRule<T> {
     public static final GameRule<Boolean> FREEZE_DAMAGE = new GameRule<>("freezeDamage", Boolean.class);
 
     /**
-     * <a href="https://minecraft-zh.gamepedia.com/%E7%81%BE%E5%8E%84%E5%B7%A1%E9%80%BB%E9%98%9F" target="_blank">灾厄巡逻队</a>是否自然生成.
+     * <a href="https://zh.minecraft.wiki/w/%E7%81%BE%E5%8E%84%E5%B7%A1%E9%80%BB%E9%98%9F" target="_blank">灾厄巡逻队</a>是否自然生成.
      */
     public static final GameRule<Boolean> DO_PATROL_SPAWNING = new GameRule<>("doPatrolSpawning", Boolean.class);
 
     /**
-     * <a href="https://minecraft-zh.gamepedia.com/%E6%B5%81%E6%B5%AA%E5%95%86%E4%BA%BA" target="_blank">流浪商人</a>是否自然生成.
+     * <a href="https://zh.minecraft.wiki/w/%E6%B5%81%E6%B5%AA%E5%95%86%E4%BA%BA" target="_blank">流浪商人</a>是否自然生成.
      */
     public static final GameRule<Boolean> DO_TRADER_SPAWNING = new GameRule<>("doTraderSpawning", Boolean.class);
 

--- a/BukkitApi/org/bukkit/Raid.java
+++ b/BukkitApi/org/bukkit/Raid.java
@@ -7,7 +7,7 @@ import org.bukkit.entity.Raider;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * 代表袭击事件 (<a href="https://minecraft-zh.gamepedia.com/%E8%A2%AD%E5%87%BB" target="_blank">Minecraft Wiki - 袭击</a>).
+ * 代表袭击事件 (<a href="https://zh.minecraft.wiki/w/%E8%A2%AD%E5%87%BB" target="_blank">Minecraft Wiki - 袭击</a>).
  */
 public interface Raid {
 

--- a/BukkitApi/org/bukkit/attribute/AttributeModifier.java
+++ b/BukkitApi/org/bukkit/attribute/AttributeModifier.java
@@ -225,7 +225,7 @@ public class AttributeModifier implements ConfigurationSerializable, Keyed {
          * <p>
          * 原文: Adds this scalar of amount to the base value
          * <p>
-         * 译注: 即 <a href="https://minecraft-zh.gamepedia.com/%E5%B1%9E%E6%80%A7#%E8%BF%90%E7%AE%97%E6%A8%A1%E5%BC%8F" target="_blank">Minecraft Wiki - 属性#运算模式</a> 中的 "倍率增量".
+         * 译注: 即 <a href="https://zh.minecraft.wiki/w/%E5%B1%9E%E6%80%A7#%E8%BF%90%E7%AE%97%E6%A8%A1%E5%BC%8F" target="_blank">Minecraft Wiki - 属性#运算模式</a> 中的 "倍率增量".
          * 该运算模式与下一个运算模式 "最终倍乘" 的区别在于, 若拥有多个该运算模式的修饰符, 会将修饰值都加起来进行一次运算, 而拥有多少个 "最终倍乘" 修饰符就会进行多少次相乘运算 (导致属性值变得很大).
          */
         ADD_SCALAR,

--- a/BukkitApi/org/bukkit/attribute/package-info.java
+++ b/BukkitApi/org/bukkit/attribute/package-info.java
@@ -1,4 +1,4 @@
 /**
- * 与属性有关的类 (<a href="https://minecraft-zh.gamepedia.com/%E5%B1%9E%E6%80%A7" target="_blank">Minecraft Wiki - 属性</a>).
+ * 与属性有关的类 (<a href="https://zh.minecraft.wiki/w/%E5%B1%9E%E6%80%A7" target="_blank">Minecraft Wiki - 属性</a>).
  */
 package org.bukkit.attribute;

--- a/BukkitApi/org/bukkit/block/structure/package-info.java
+++ b/BukkitApi/org/bukkit/block/structure/package-info.java
@@ -1,4 +1,4 @@
 /**
- * 与结构方块有关的类 (<a href="https://minecraft-zh.gamepedia.com/%E7%BB%93%E6%9E%84%E6%96%B9%E5%9D%97" target="_blank">Minecraft Wiki - 结构方块</a>).
+ * 与结构方块有关的类 (<a href="https://zh.minecraft.wiki/w/%E7%BB%93%E6%9E%84%E6%96%B9%E5%9D%97" target="_blank">Minecraft Wiki - 结构方块</a>).
  */
 package org.bukkit.block.structure;

--- a/BukkitApi/org/bukkit/entity/AreaEffectCloud.java
+++ b/BukkitApi/org/bukkit/entity/AreaEffectCloud.java
@@ -15,8 +15,8 @@ import org.jetbrains.annotations.Nullable;
  * 代表一片即将对处于其中的生物施加药水效果的区域效果云 (即喷溅药水使用后形成的雾).
  * <p>
  * 参考：
- * <a href='http://minecraft-zh.gamepedia.com/%E5%8C%BA%E5%9D%97%E6%A0%BC%E5%BC%8F#AreaEffectCloud'>区块格式#AreaEffectCloud</a> 
- * <a href='http://minecraft-zh.gamepedia.com/%E6%BB%9E%E7%95%99%E8%8D%AF%E6%B0%B4'>滞留药水</a>
+ * <a href='http://zh.minecraft.wiki/w/%E5%8C%BA%E5%9D%97%E6%A0%BC%E5%BC%8F#AreaEffectCloud'>区块格式#AreaEffectCloud</a> 
+ * <a href='http://zh.minecraft.wiki/w/%E6%BB%9E%E7%95%99%E8%8D%AF%E6%B0%B4'>滞留药水</a>
  */
 public interface AreaEffectCloud extends Entity {
 

--- a/BukkitApi/org/bukkit/entity/Illager.java
+++ b/BukkitApi/org/bukkit/entity/Illager.java
@@ -1,6 +1,6 @@
 package org.bukkit.entity;
 
 /**
- * 代表一种"灾厄村民" (亦称刌民), 包含卫道士、女巫等. 详见<a href="https://minecraft-zh.gamepedia.com/%E7%81%BE%E5%8E%84%E6%9D%91%E6%B0%91" target="_blank">Minecraft Wiki - 灾厄村民</a>的介绍.
+ * 代表一种"灾厄村民" (亦称刌民), 包含卫道士、女巫等. 详见<a href="https://zh.minecraft.wiki/w/%E7%81%BE%E5%8E%84%E6%9D%91%E6%B0%91" target="_blank">Minecraft Wiki - 灾厄村民</a>的介绍.
  */
 public interface Illager extends Raider { }

--- a/BukkitApi/org/bukkit/entity/Painting.java
+++ b/BukkitApi/org/bukkit/entity/Painting.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * 代表画.
  * <p>
- * 前往<a href="http://minecraft-zh.gamepedia.com/%E7%94%BB">wiki</a>了解更多
+ * 前往<a href="http://zh.minecraft.wiki/w/%E7%94%BB">wiki</a>了解更多
  */
 public interface Painting extends Hanging {
 

--- a/BukkitApi/org/bukkit/entity/WitherSkull.java
+++ b/BukkitApi/org/bukkit/entity/WitherSkull.java
@@ -3,7 +3,7 @@ package org.bukkit.entity;
 /**
  * 代表凋零之首.
  * <p>
- * 有关凋零之首，请参阅 MineCraft 中文Wiki 上的<a href="http://minecraft-zh.gamepedia.com/%E5%87%8B%E9%9B%B6">凋零</a>部分.
+ * 有关凋零之首，请参阅 MineCraft 中文Wiki 上的<a href="http://zh.minecraft.wiki/w/%E5%87%8B%E9%9B%B6">凋零</a>部分.
  */
 public interface WitherSkull extends Fireball {
 

--- a/BukkitApi/org/bukkit/event/raid/package-info.java
+++ b/BukkitApi/org/bukkit/event/raid/package-info.java
@@ -1,4 +1,4 @@
 /**
- * 与袭击有关的{@link org.bukkit.event.Event 事件}(<a href="https://minecraft-zh.gamepedia.com/%E8%A2%AD%E5%87%BB" target="_blank">Minecraft Wiki - 袭击</a>).
+ * 与袭击有关的{@link org.bukkit.event.Event 事件}(<a href="https://zh.minecraft.wiki/w/%E8%A2%AD%E5%87%BB" target="_blank">Minecraft Wiki - 袭击</a>).
  */
 package org.bukkit.event.raid;

--- a/BukkitApi/org/bukkit/event/world/GenericGameEvent.java
+++ b/BukkitApi/org/bukkit/event/world/GenericGameEvent.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * 代表 Mojang 通用游戏事件.
  *
- * 你应该尽可能地使用 Bukkit 框架提供的其它事件, 此事件在游戏内部主要用于<a href="https://minecraft-zh.gamepedia.com/Sculk_Sensor">Sculk_Sensor</a>.
+ * 你应该尽可能地使用 Bukkit 框架提供的其它事件, 此事件在游戏内部主要用于<a href="https://zh.minecraft.wiki/w/Sculk_Sensor">Sculk_Sensor</a>.
  * <p>
  * 原文:Represents a generic Mojang game event.
  *

--- a/BukkitApi/org/bukkit/loot/package-info.java
+++ b/BukkitApi/org/bukkit/loot/package-info.java
@@ -1,4 +1,4 @@
 /**
- * 与战利品表产生与操作有关的类 (<a href="https://minecraft-zh.gamepedia.com/%E6%88%98%E5%88%A9%E5%93%81%E8%A1%A8" target="_blank">Minecraft Wiki - 战利品表</a>).
+ * 与战利品表产生与操作有关的类 (<a href="https://zh.minecraft.wiki/w/%E6%88%98%E5%88%A9%E5%93%81%E8%A1%A8" target="_blank">Minecraft Wiki - 战利品表</a>).
  */
 package org.bukkit.loot;

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Magic value具体是什么意思有点难以解释, 请查阅百度百科 "Magic
 ```
 -----
 # 译名标准
-对于 Minecraft 上的名词, 如果你不知道其确切的意义, 可以参考[译名标准化](https://minecraft-zh.gamepedia.com/Minecraft_Wiki:%E8%AF%91%E5%90%8D%E6%A0%87%E5%87%86%E5%8C%96) 和 [1.13 扁平化](https://minecraft-zh.gamepedia.com/1.13/%E6%89%81%E5%B9%B3%E5%8C%96). 尽量使用官译名.
+对于 Minecraft 上的名词, 如果你不知道其确切的意义, 可以参考[译名标准化](https://zh.minecraft.wiki/w/Minecraft_Wiki:%E8%AF%91%E5%90%8D%E6%A0%87%E5%87%86%E5%8C%96) 和 [1.13 扁平化](https://zh.minecraft.wiki/w/1.13/%E6%89%81%E5%B9%B3%E5%8C%96). 尽量使用官译名.
 # 翻译须知
 ## 翻译质量  
 **严禁直接机翻, 若实在不会*请以单词和句子结构为单位进行查询*, 加入自己的理解, 重新组织语言. 否则将撤回**


### PR DESCRIPTION
将Minecraft Wiki旧站点（minecraft.fandom.com及minecraft-zh.gamepedia.com）的链接修改至新站点的链接（zh.minecraft.wiki）